### PR TITLE
Change LDC version to 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v1.34.0
+
+- ldc compiler version bumped to v1.34.0
+- dub package manager version bumped to v1.33.1
+- ld.gold (v1.16) setted up as default linker instead of ld.bfd (v2.40)
+- `Dockerfile` refactored: size of the image slightly decreased (using multistage for building final image, removal of unnecessary packages)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG arg_compiler=ldc
-ARG arg_compiler_version=1.33.0
+ARG arg_compiler_version=1.34.0
 
 FROM debian:bookworm-slim AS builder
 
@@ -54,7 +54,7 @@ RUN apt-get -yqq -o=Dpkg::Use-Pty=0 update \
   && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install ca-certificates libterm-readline-gnu-perl \
   curl \
   binutils-gold gcc gcc-multilib \
-  libxml2-dev zlib1g-dev \
+  libxml2-dev zlib1g-dev libssl-dev \
   && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20 \
   && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10 \
   && ldconfig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,63 @@
-FROM debian:bookworm-slim
+ARG arg_compiler=ldc
+ARG arg_compiler_version=1.33.0
 
-LABEL org.opencontainers.image.authors="Stefan Rohe <think@hotmail.de>"
-LABEL org.opencontainers.image.authors="Filipp Chertiev <f@fzfx.ru>"
+FROM debian:bookworm-slim AS builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV \
-  COMPILER=ldc \
-  COMPILER_BIN=${COMPILER}2 \
-  COMPILER_VERSION=1.33.0
+ARG arg_compiler
+ARG arg_compiler_version
 
-RUN apt-get -yqq -o=Dpkg::Use-Pty=0 update && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install apt-utils
-
-RUN apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install binutils-gold gcc gcc-multilib \
-  libxml2-dev zlib1g-dev libssl-dev \
-  ca-certificates libterm-readline-gnu-perl \
-  wget curl xz-utils gpg gpg-agent git dirmngr \
-  && curl -fsS -o /tmp/install.sh https://dlang.org/install.sh \
-  && bash /tmp/install.sh -p /dlang install "${COMPILER}-${COMPILER_VERSION}" \
-  && rm /tmp/install.sh \
-  && rm -rf /dlang/${COMPILER}-*/lib32
-  
-ENV \
-  PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/bin:${PATH}" \
-  LD_LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
-  LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
-  PS1="(${COMPILER}-${COMPILER_VERSION}) \\u@\\h:\\w\$" \
-  DC=${COMPILER_BIN}
-
-RUN ldconfig
-
-WORKDIR /src
-
-ENV GOSU_VERSION 1.14
-RUN wget --no-verbose -O /usr/local/bin/gosu \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-  && wget --no-verbose -O /usr/local/bin/gosu.asc \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }').asc" \
+ENV DEBIAN_FRONTEND=noninteractive \
+  COMPILER=$arg_compiler \
+  COMPILER_VERSION=$arg_compiler_version
+ENV GOSU_VERSION=1.14
+RUN ln -sf /bin/bash /bin/sh
+RUN apt-get -yqq -o=Dpkg::Use-Pty=0 update \
+  && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install apt-utils \
+  && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install ca-certificates libterm-readline-gnu-perl \
+  curl xz-utils gpg gpg-agent dirmngr \
+  && bash <(curl -LfsS https://dlang.org/install.sh) -p /dlang install "${COMPILER}-${COMPILER_VERSION}" \
+  && rm -rf /dlang/${COMPILER}-*/lib32 \
+  && curl -LfsS -o /usr/local/bin/gosu \
+  "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+  && curl -LfsS -o /usr/local/bin/gosu.asc \
+  "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }').asc" \
   && export GNUPGHOME="$(mktemp -d)" \
   && gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
   && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
   && rm -rf "${GNUPGHOME}" /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu \
-  && gosu nobody true \
-  && apt-get -yqq -o=Dpkg::Use-Pty=0 auto-remove wget curl xz-utils gpg gpg-agent wget dirmngr \
+  && gosu nobody true
+
+FROM debian:bookworm-slim
+
+LABEL org.opencontainers.image.authors="Stefan Rohe <think@hotmail.de>"
+LABEL org.opencontainers.image.authors="Filipp Chertiev <f@fzfx.ru>"
+
+ARG arg_compiler
+ARG arg_compiler_version
+
+WORKDIR /src
+
+ENV DEBIAN_FRONTEND=noninteractive \
+  COMPILER=$arg_compiler \
+  COMPILER_VERSION=$arg_compiler_version
+ENV COMPILER_BIN=${COMPILER}2 \
+  PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/bin:${PATH}" \
+  LD_LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
+  LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
+  PS1="(${COMPILER}-${COMPILER_VERSION}) \\u@\\h:\\w\$" \
+  DC=${COMPILER_BIN}
+COPY --from=builder /dlang /dlang
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
+RUN apt-get -yqq -o=Dpkg::Use-Pty=0 update \
+  && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install apt-utils \
+  && apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install ca-certificates libterm-readline-gnu-perl \
+  curl \
+  binutils-gold gcc gcc-multilib \
+  libxml2-dev zlib1g-dev \
+  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20 \
+  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10 \
+  && ldconfig \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /var/cache/apt \
   && rm -rf /var/log/apt \

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Docker image allows to use LDC compiler without installation.
 ## Includes (latest version)
 
 - Debian 12 (bookworm) environment
-- ldc2 compiler v1.33.0
-- dub package manager v1.32.1
+- ldc2 compiler v1.34.0
+- ld.gold linker v1.16
+- ld.bfd linker v2.40
+- dub package manager v1.33.1
 - libxml2 library v2.9.14
 - libz (zlib) library v1.2.13
 - libssl library v3.0.9


### PR DESCRIPTION
# v1.34.0

- ldc compiler version bumped to v1.34.0
- dub package manager version bumped to v1.33.1
- ld.gold (v1.16) setted up as default linker instead of ld.bfd (v2.40)
- `Dockerfile` refactored: size of the image slightly decreased (using multistage for building final image, removal of unnecessary packages)