### PR TITLE
Change LDC version to 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v1.37.0
+
 - Change LDC version to 1.37.0
 - Change dub package manager version to 1.36.0
 - Removed packages related to GPG (not needed since removed `gosu` usage)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.37.0
+- Change LDC version to 1.37.0
+- Change dub package manager version to 1.36.0
+- Removed packages related to GPG (not needed since removed `gosu` usage)
+
 # v1.36.0
 
 - [Change LDC version to 1.36.0](https://github.com/vreitech/docker-ldc/commit/c2ab662a240f41da1cd337461c49deaccb91690b)
@@ -17,3 +22,4 @@
 - Change dub package manager version to 1.33.1
 - ld.gold (v1.16) setted up as default linker instead of ld.bfd (v2.40)
 - `Dockerfile` refactored: size of the image slightly decreased (using multistage for building final image, removal of unnecessary packages)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG arg_compiler=ldc
-ARG arg_compiler_version=1.36.0
+ARG arg_compiler=ldc2
+ARG arg_compiler_version=1.37.0
 
 FROM debian:bookworm-slim AS builder
 
@@ -14,9 +14,10 @@ RUN <<EOF bash
   apt-get -yqq -o=Dpkg::Use-Pty=0 update
   apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install apt-utils
   apt-get -yqq -o=Dpkg::Use-Pty=0 --no-install-recommends install ca-certificates libterm-readline-gnu-perl \
-  curl xz-utils gpg gpg-agent dirmngr
-  bash <(curl -LfsS https://dlang.org/install.sh) -p /dlang install "${COMPILER}-${COMPILER_VERSION}"
-  rm -rf /dlang/${COMPILER}-*/lib32
+  curl xz-utils
+  mkdir -p /dlang
+  tar xJf <(curl -LfsS "https://github.com/ldc-developers/ldc/releases/download/v${COMPILER_VERSION}/${COMPILER}-${COMPILER_VERSION}-linux-x86_64.tar.xz") -C /dlang
+  rm -rf /dlang/${COMPILER}-${COMPILER_VERSION}-linux-x86_64/lib32
 EOF
 
 FROM debian:bookworm-slim
@@ -32,10 +33,10 @@ WORKDIR /src
 ENV DEBIAN_FRONTEND=noninteractive \
   COMPILER=$arg_compiler \
   COMPILER_VERSION=$arg_compiler_version
-ENV COMPILER_BIN=${COMPILER}2 \
-  PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/bin:${PATH}" \
-  LD_LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
-  LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}/lib" \
+ENV COMPILER_BIN=${COMPILER} \
+  PATH="/dlang/${COMPILER}-${COMPILER_VERSION}-linux-x86_64/bin:${PATH}" \
+  LD_LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}-linux-x86_64/lib" \
+  LIBRARY_PATH="/dlang/${COMPILER}-${COMPILER_VERSION}-linux-x86_64/lib" \
   PS1="(${COMPILER}-${COMPILER_VERSION}) \\u@\\h:\\w\$" \
   DC=${COMPILER_BIN}
 COPY --from=builder /dlang /dlang

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Docker image allows to use LDC compiler without installation.
 ## Includes (latest version)
 
 - Debian 12 (bookworm) environment
-- ldc2 compiler v1.36.0
+- ldc2 compiler v1.37.0
 - ld.gold linker v1.16
 - ld.bfd linker v2.40
-- dub package manager v1.35.1
+- dub package manager v1.36.0
 - libxml2 library v2.9.14
 - libz (zlib) library v1.2.13
 - libssl library v3.0.11
@@ -41,3 +41,4 @@ or
 ```
 docker run --rm -it -v "$(pwd):/src" ghcr.io/vreitech/docker-ldc ldc2 test.d
 ```
+


### PR DESCRIPTION
- Change LDC version to 1.37.0
- Change dub package manager version to 1.36.0
- Removed packages related to GPG (not needed since removed `gosu` usage)